### PR TITLE
fixing type error.

### DIFF
--- a/ch02/params.json
+++ b/ch02/params.json
@@ -7,7 +7,7 @@
     "ssh_user" : "centos",
     "provider" : "azure",
     "node_count" : 1,
-    "windows_node_count" 1,
+    "windows_node_count": 1,
     "firewall_allow" : [ "0.0.0.0/0" ],
-    "cloud_region" : "uksouth",
+    "cloud_region" : "uksouth"
 }


### PR DESCRIPTION
This type type error makes impossible to execute the module. The json-file can not be parsed.